### PR TITLE
Hotfix/#63 utc kst connection setting

### DIFF
--- a/src/main/java/com/example/gujeuck_server/domain/log/service/CreateLogService.java
+++ b/src/main/java/com/example/gujeuck_server/domain/log/service/CreateLogService.java
@@ -9,6 +9,7 @@ import com.example.gujeuck_server.domain.purpose.domain.Purpose;
 
 import com.example.gujeuck_server.domain.purpose.facade.PurposeFacade;
 import com.example.gujeuck_server.global.utility.DateFormatter;
+import com.example.gujeuck_server.global.utility.TimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +24,6 @@ public class CreateLogService {
     private final OrganFacade organFacade;
     private final PurposeFacade purposeFacade;
 
-    private static final String TIME = "HH:mm";
     private static final String KOREAN_DATE_REGEX = "\\d{4}년\\d{2}월\\d{2}일";
 
     @Transactional
@@ -31,7 +31,7 @@ public class CreateLogService {
 
         Organ organ = organFacade.currentOrgan();
 
-        int currentYear = LocalDate.now().getYear();
+        int currentYear = TimeProvider.nowYear();
 
         Purpose purpose = purposeFacade.getPurpose(organ.getId(), request.getPurpose());
 

--- a/src/main/java/com/example/gujeuck_server/domain/log/service/CreateLogService.java
+++ b/src/main/java/com/example/gujeuck_server/domain/log/service/CreateLogService.java
@@ -14,8 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -33,15 +31,14 @@ public class CreateLogService {
 
         Organ organ = organFacade.currentOrgan();
 
-        String visitTime = LocalTime.now().format(DateTimeFormatter.ofPattern(TIME));
-
         int currentYear = LocalDate.now().getYear();
 
         Purpose purpose = purposeFacade.getPurpose(organ.getId(), request.getPurpose());
 
         String formattedDate = resolveVisitDate(request.getVisitDate());
 
-        Log log = createUseLog(request, purpose, formattedDate, visitTime, currentYear, organ);
+        Log log = createUseLog(request, purpose, formattedDate, request.getVisitTime(), currentYear, organ);
+
         logRepository.save(log);
     }
 

--- a/src/main/java/com/example/gujeuck_server/domain/user/service/LoginUserService.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/service/LoginUserService.java
@@ -6,14 +6,10 @@ import com.example.gujeuck_server.domain.user.presentation.dto.request.LoginRequ
 import com.example.gujeuck_server.domain.user.domain.User;
 import com.example.gujeuck_server.domain.user.domain.repository.UserRepository;
 import com.example.gujeuck_server.domain.user.exception.UserNotFoundException;
-import com.example.gujeuck_server.global.utility.DateFormatter;
+import com.example.gujeuck_server.global.utility.TimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -21,8 +17,6 @@ public class LoginUserService {
 
     private final UserRepository userRepository;
     private final LogRepository logRepository;
-
-    private static final String TIME = "HH:mm";
 
     @Transactional
     public void execute(LoginRequest request) {
@@ -32,11 +26,11 @@ public class LoginUserService {
 
         user.increaseCount();
 
-        String visitDate = DateFormatter.LocalDateForm(LocalDate.now());;
+        String visitDate = TimeProvider.nowDateFormatted();
 
-        String visitTime = LocalTime.now().format(DateTimeFormatter.ofPattern(TIME));;
+        String visitTime = TimeProvider.nowTimeFormatted();
 
-        int currentYear = LocalDate.now().getYear();
+        int currentYear = TimeProvider.nowYear();
 
         Log log = createUserLog(user, request, visitDate, visitTime, currentYear);
 

--- a/src/main/java/com/example/gujeuck_server/domain/user/service/SignupService.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/service/SignupService.java
@@ -13,14 +13,10 @@ import com.example.gujeuck_server.domain.user.domain.repository.UserRepository;
 import com.example.gujeuck_server.domain.user.presentation.dto.request.SignupRequest;
 import com.example.gujeuck_server.domain.user.presentation.dto.response.SignUpResponse;
 import com.example.gujeuck_server.global.utility.CalculateAgeService;
-import com.example.gujeuck_server.global.utility.DateFormatter;
+import com.example.gujeuck_server.global.utility.TimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -32,8 +28,6 @@ public class SignupService {
     private final PurposeFacade purposeFacade;
     private final OrganFacade organFacade;
 
-    private static final String TIME = "HH:mm";
-
     @Transactional
     public SignUpResponse execute(SignupRequest request) {
 
@@ -43,11 +37,11 @@ public class SignupService {
 
         Age age = calculateAgeService.getAge(request.getBirthYMD());
 
-        String visitDate = DateFormatter.LocalDateForm(LocalDate.now());;
+        String visitDate = TimeProvider.nowDateFormatted();
 
-        String visitTime = LocalTime.now().format(DateTimeFormatter.ofPattern(TIME));
+        String visitTime = TimeProvider.nowTimeFormatted();
 
-        int currentYear = LocalDate.now().getYear();
+        int currentYear = TimeProvider.nowYear();
 
         Purpose purpose = purposeFacade.getPurpose(organ.getId(), request.getPurpose());
 

--- a/src/main/java/com/example/gujeuck_server/global/utility/TimeProvider.java
+++ b/src/main/java/com/example/gujeuck_server/global/utility/TimeProvider.java
@@ -1,0 +1,41 @@
+package com.example.gujeuck_server.global.utility;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TimeProvider {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static LocalDate nowDate() {
+        return ZonedDateTime.now(KOREA_ZONE).toLocalDate();
+    }
+
+    public static LocalTime nowTime() {
+        return ZonedDateTime.now(KOREA_ZONE).toLocalTime();
+    }
+
+    public static int nowYear() {
+        return ZonedDateTime.now(KOREA_ZONE).getYear();
+    }
+
+    public static String nowDateFormatted() {
+        return DateFormatter.LocalDateForm(nowDate());
+    }
+
+    public static String nowTimeFormatted() {
+        return nowTime().format(TIME_FORMATTER);
+    }
+
+    public static ZonedDateTime nowZoned() {
+        return ZonedDateTime.now(KOREA_ZONE);
+    }
+}


### PR DESCRIPTION
기존 utc기반 time zone사용으로 밀리는 데이터들 발생 -> TimeProvider util클래스 구현 후 time zone고정해서 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 시간대 처리 로직을 중앙 집중식으로 통합하여 한국 표준시(Asia/Seoul) 기준으로 일관된 시간 관리 구현
  * 방문 시간 데이터 처리 방식을 개선하여 요청에서 제공된 방문 시간 우선 사용
  * 기존 서비스들에서 시간/연도 포맷터를 통합 유틸리티로 전환하여 중복 제거 및 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->