### PR TITLE
feat(#82) :: Flyway 도입 및 user_id 컬럼 드리프트 정리

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,8 +26,9 @@ spring:
       ddl-auto: update
 
   flyway:
-    enabled: false
+    enabled: true
     baseline-on-migrate: true
+    baseline-version: 6
     locations: classpath:db/migration
     validate-on-migrate: false
 

--- a/src/main/resources/db/migration/V7__drop_user_user_id.sql
+++ b/src/main/resources/db/migration/V7__drop_user_user_id.sql
@@ -1,0 +1,18 @@
+-- 폐기된 String userId 컬럼(user.user_id) 제거.
+-- 환경마다 컬럼 존재 여부가 달라(local/신규 DB에는 없음, develop/prod에는 남아있음)
+-- MySQL은 DROP COLUMN IF EXISTS를 지원하지 않으므로 information_schema로 확인 후 조건부로 드롭한다. (멱등)
+SET @user_id_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'user'
+      AND COLUMN_NAME = 'user_id'
+);
+
+SET @ddl := IF(@user_id_exists > 0,
+    'ALTER TABLE `user` DROP COLUMN user_id',
+    'DO 0');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## 개요

`userId` 필드 제거(#78) 이후 develop/prod DB에 남아 있는 `user.user_id` 컬럼(NOT NULL, 기본값 없음) 때문에 회원가입 insert가 500으로 실패하는 스키마 드리프트를 Flyway 마이그레이션으로 해결합니다.

서버/DB에 직접 접근하지 않고 **배포 시 자동으로 적용**되도록 Flyway를 도입했습니다.

## 변경 사항

- `application.yml`: Flyway 활성화(`enabled: true`) 및 `baseline-version: 6` 설정
  - 기존 Hibernate(`ddl-auto: update`)로 만들어진 스키마를 보호하고, 의미 없는 V1~V6 재실행을 방지하기 위해 현재 DB를 V6 기준으로 baseline 처리
- `V7__drop_user_user_id.sql` 추가: `user.user_id` 컬럼 제거
  - 환경별 컬럼 존재 여부가 다르고(MySQL은 `DROP COLUMN IF EXISTS` 미지원) `information_schema`로 확인 후 조건부 드롭하여 멱등성 보장

## 배포 시 동작

1. 앱 기동 시 `flyway_schema_history`가 없으면 현재 DB를 baseline(v6)으로 스냅샷
2. `V7` 적용 → `user_id` 컬럼 제거 → 드리프트 해소
3. 이후 재배포에서는 재실행되지 않음(멱등). prod는 main 배포 시 동일하게 1회 적용

## 검증 (로컬 DB)

- 컬럼 없음(로컬/신규 환경): no-op, 에러 없음 ✅
- 두 번 실행(재실행 안전성): 안전 ✅
- 컬럼 있음(develop 상황 모사): 정상 드롭 ✅

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 데이터베이스 마이그레이션이 다시 활성화되어, 배포 시 변경사항이 자동으로 반영될 수 있게 되었습니다.
  * 초기 기준 버전이 명시되어 마이그레이션 적용 기준이 더 분명해졌습니다.

* **Bug Fixes**
  * 더 이상 사용하지 않는 `user` 테이블의 컬럼이 안전하게 제거되도록 개선되었습니다.
  * 환경에 따라 해당 컬럼이 없더라도 오류 없이 처리되도록 해 안정성이 높아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->