### PR TITLE
chore :: 홈서버 CI/CD를 AWS EC2 배포로 전환

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -101,14 +101,14 @@ jobs:
       - name: Push deployment image
         run: docker push "${{ steps.meta.outputs.image_ref }}"
 
-  deploy-home:
-    name: Deploy Home Server
+  deploy:
+    name: Deploy to AWS EC2
     needs: [verify, package-image]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-    runs-on: [self-hosted, gujeuk-home-server]
-    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     concurrency:
-      group: gujeuk-home-deploy
+      group: gujeuk-aws-deploy-${{ needs.package-image.outputs.deploy_target }}
       cancel-in-progress: false
 
     steps:
@@ -116,191 +116,85 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set deployment target
+        id: target
         run: |
           set -euo pipefail
 
-          if [ "${GITHUB_REF_NAME}" = "main" ]; then
-            echo "DEPLOY_DIR=/home/ubuntu/git/gujeuk-check-in-server" >> "$GITHUB_ENV"
-            echo "PUBLIC_HEALTH_URL=https://api.taisu.site/public/organs" >> "$GITHUB_ENV"
+          if [ "${{ needs.package-image.outputs.deploy_target }}" = "prod" ]; then
+            echo "remote_dir=/home/ubuntu/gujeuk-aws/prod" >> "$GITHUB_OUTPUT"
+            echo "local_port=8080" >> "$GITHUB_OUTPUT"
+            echo "public_health_url=https://aws-api.oijwef098234.com/purpose/all" >> "$GITHUB_OUTPUT"
           else
-            echo "DEPLOY_DIR=/home/ubuntu/git/gujeuk-check-in-server-stag" >> "$GITHUB_ENV"
-            echo "PUBLIC_HEALTH_URL=https://api-stag.taisu.site/public/organs" >> "$GITHUB_ENV"
+            echo "remote_dir=/home/ubuntu/gujeuk-aws/stag" >> "$GITHUB_OUTPUT"
+            echo "local_port=8081" >> "$GITHUB_OUTPUT"
+            echo "public_health_url=https://aws-stag.oijwef098234.com/purpose/all" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Sync source to deployment directory
-        run: |
-          set -euo pipefail
-
-          mkdir -p "$DEPLOY_DIR"
-
-          rsync -a --delete \
-            --exclude='.git/' \
-            --exclude='.env' \
-            --exclude='.env.backup.*' \
-            --exclude='backups/' \
-            --exclude='imports/' \
-            --exclude='build/' \
-            --exclude='.gradle/' \
-            ./ "$DEPLOY_DIR"/
-
-      - name: Validate deployment environment
-        run: |
-          set -euo pipefail
-
-          test -f "$DEPLOY_DIR/.env"
-          docker --version
-          docker compose version
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
+      - name: Copy docker-compose file to EC2
+        uses: appleboy/scp-action@v0.1.7
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install home server recovery scripts
-        run: |
-          set -euo pipefail
-
-          install -m 0755 \
-            ops/home-server/start-cloudflared.sh \
-            /home/ubuntu/bin/start-cloudflared.sh
-          install -m 0755 \
-            ops/home-server/watch-cloudflared.sh \
-            /home/ubuntu/bin/watch-cloudflared.sh
-          install -m 0755 \
-            ops/home-server/server-shutdown \
-            /home/ubuntu/bin/server-shutdown
-          install -m 0755 \
-            ops/home-server/gujeuk-rtcwake \
-            /home/ubuntu/bin/gujeuk-rtcwake
-          install -m 0755 \
-            ops/home-server/install-shutdown-nopasswd.sh \
-            /home/ubuntu/bin/install-shutdown-nopasswd.sh
-          install -m 0755 \
-            ops/home-server/notify-server-resumed \
-            /home/ubuntu/bin/notify-server-resumed
-          install -m 0755 \
-            ops/home-server/deploy-stack.sh \
-            /home/ubuntu/bin/deploy-stack.sh
-          install -m 0755 \
-            ops/home-server/gujeuk-promote-replica \
-            /home/ubuntu/bin/gujeuk-promote-replica
-          ln -sfn \
-            /home/ubuntu/bin/server-shutdown \
-            /home/ubuntu/bin/shutdown
-
-      - name: Pull deployment image
-        run: |
-          set -euo pipefail
-
-          docker pull "${{ needs.package-image.outputs.image_ref }}"
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "ops/aws/docker-compose.aws.yml"
+          target: "/tmp/gujeuk-deploy-${{ needs.package-image.outputs.deploy_target }}"
+          strip_components: 2
 
       - name: Deploy application
-        run: |
-          set -euo pipefail
-
-          /home/ubuntu/bin/deploy-stack.sh \
-            "$DEPLOY_DIR" \
-            "$DEPLOY_DIR/.env" \
-            "${{ needs.package-image.outputs.image_ref }}" \
-            "$PUBLIC_HEALTH_URL"
-
-      - name: Prune unused Docker images
-        if: always()
-        run: docker image prune -f
-
-  notify-home-discord:
-    name: Notify Home Discord
-    needs: [verify, package-image, deploy-home]
-    if: ${{ always() && github.event_name != 'pull_request' }}
-    runs-on: [self-hosted, gujeuk-home-server]
-
-    steps:
-      - name: Send Korean Discord notification
+        uses: appleboy/ssh-action@v1.0.3
         env:
-          VERIFY_RESULT: ${{ needs.verify.result }}
-          PACKAGE_RESULT: ${{ needs.package-image.result }}
-          DEPLOY_RESULT: ${{ needs.deploy-home.result }}
-          REPOSITORY: ${{ github.repository }}
-          REF_NAME: ${{ github.ref_name }}
-          EVENT_NAME: ${{ github.event_name }}
-          ACTOR: ${{ github.actor }}
-          SHA: ${{ github.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          IMAGE_REF: ${{ needs.package-image.outputs.image_ref }}
+          REMOTE_DIR: ${{ steps.target.outputs.remote_dir }}
+          LOCAL_PORT: ${{ steps.target.outputs.local_port }}
+          DEPLOY_TARGET: ${{ needs.package-image.outputs.deploy_target }}
+          GHCR_ACTOR: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          envs: IMAGE_REF,REMOTE_DIR,LOCAL_PORT,DEPLOY_TARGET,GHCR_ACTOR,GHCR_TOKEN
+          script_stop: true
+          script: |
+            set -euo pipefail
+
+            mkdir -p "$REMOTE_DIR"
+            cp "/tmp/gujeuk-deploy-${DEPLOY_TARGET}/docker-compose.aws.yml" "$REMOTE_DIR/docker-compose.yml"
+            rm -rf "/tmp/gujeuk-deploy-${DEPLOY_TARGET}"
+
+            cd "$REMOTE_DIR"
+            test -f .env
+
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+
+            export APP_IMAGE="$IMAGE_REF"
+            docker compose --env-file .env pull app
+            docker compose --env-file .env up -d
+
+            for i in $(seq 1 10); do
+              if curl -fs "http://localhost:${LOCAL_PORT}/purpose/all" >/dev/null; then
+                echo "local health check OK"
+                break
+              fi
+              if [ "$i" = "10" ]; then
+                echo "local health check FAILED"
+                exit 1
+              fi
+              sleep 3
+            done
+
+            docker image prune -f
+
+      - name: Public health check
         run: |
           set -euo pipefail
-
-          if [ ! -x /home/ubuntu/bin/discord-notify ]; then
-            echo "/home/ubuntu/bin/discord-notify is not installed; skipping Discord notification."
-            exit 0
-          fi
-
-          translate_result() {
-            case "$1" in
-              success) echo "성공" ;;
-              failure) echo "실패" ;;
-              cancelled) echo "취소됨" ;;
-              skipped) echo "건너뜀" ;;
-              *) echo "$1" ;;
-            esac
-          }
-
-          VERIFY_RESULT_KO="$(translate_result "$VERIFY_RESULT")"
-          PACKAGE_RESULT_KO="$(translate_result "$PACKAGE_RESULT")"
-          DEPLOY_RESULT_KO="$(translate_result "$DEPLOY_RESULT")"
-          COMMIT_SHORT="${SHA:0:7}"
-
-          if [ "$VERIFY_RESULT" != "success" ]; then
-            TITLE="🚨 긴급: 구즉 CI 빌드 실패"
-            COLOR=15158332
-            REFLECT_RESULT="실패"
-            SUMMARY="커밋이 서버에 반영되지 않았습니다. 검증 단계에서 실패했습니다."
-          elif [ "$PACKAGE_RESULT" != "success" ]; then
-            TITLE="🚨 긴급: 구즉 배포 이미지 생성 실패"
-            COLOR=15158332
-            REFLECT_RESULT="실패"
-            SUMMARY="검증은 통과했지만 배포 이미지 생성에 실패했습니다."
-          elif [ "$REF_NAME" = "main" ] && [ "$EVENT_NAME" = "push" ] && [ "$DEPLOY_RESULT" = "success" ]; then
-            TITLE="구즉 운영 배포 완료"
-            COLOR=3066993
-            REFLECT_RESULT="완료"
-            SUMMARY="main 브랜치 커밋이 운영 서버에 정상 반영되었습니다."
-          elif [ "$REF_NAME" = "develop" ] && [ "$EVENT_NAME" = "push" ] && [ "$DEPLOY_RESULT" = "success" ]; then
-            TITLE="구즉 스테이징 배포 완료"
-            COLOR=3447003
-            REFLECT_RESULT="완료"
-            SUMMARY="develop 브랜치 커밋이 스테이징 서버에 정상 반영되었습니다."
-          elif [ "$REF_NAME" = "main" ] && [ "$EVENT_NAME" = "push" ]; then
-            TITLE="🚨 긴급: 구즉 운영 배포 실패"
-            COLOR=15158332
-            REFLECT_RESULT="실패"
-            SUMMARY="운영 서버 배포 중 문제가 발생했습니다."
-          elif [ "$REF_NAME" = "develop" ] && [ "$EVENT_NAME" = "push" ]; then
-            TITLE="🚨 긴급: 구즉 스테이징 배포 실패"
-            COLOR=15158332
-            REFLECT_RESULT="실패"
-            SUMMARY="스테이징 서버 배포 중 문제가 발생했습니다."
-          else
-            TITLE="구즉 CI 검사 완료"
-            COLOR=3447003
-            REFLECT_RESULT="배포 대상 아님"
-            SUMMARY="검증은 통과했지만 배포 대상 브랜치 push가 아니어서 서버 반영은 진행하지 않았습니다."
-          fi
-
-          MESSAGE="$(cat <<MSG
-          $SUMMARY
-
-          커밋 반영: $REFLECT_RESULT
-          브랜치: $REF_NAME
-          커밋: $COMMIT_SHORT
-          실행자: $ACTOR
-          검증: $VERIFY_RESULT_KO
-          이미지 생성: $PACKAGE_RESULT_KO
-          배포: $DEPLOY_RESULT_KO
-          저장소: $REPOSITORY
-          Actions: $RUN_URL
-          MSG
-          )"
-
-          /home/ubuntu/bin/discord-notify "$TITLE" "$MESSAGE" "$COLOR" || true
+          for i in $(seq 1 10); do
+            STATUS=$(curl -fs -o /dev/null -w "%{http_code}" "${{ steps.target.outputs.public_health_url }}" || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "public health check OK"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "public health check FAILED (last status: $STATUS)"
+          exit 1


### PR DESCRIPTION
## Summary
- 기존 홈서버 self-hosted runner + rsync 배포 방식을 제거하고, GitHub-hosted runner에서 SSH로 AWS EC2(`i-05e2a254f15e59ead`, `3.37.79.125`)에 직접 배포하는 방식으로 교체
- `main` push → prod(8080), `develop` push → stag(8081) — 기존 브랜치 정책 그대로 유지
- 배포 시 `ops/aws/docker-compose.aws.yml`을 서버에 동기화한 뒤 이미지만 교체(pull + up -d)
- GHCR private 이미지는 워크플로우 실행 중에만 유효한 `GITHUB_TOKEN`으로 EC2에서 로그인 후 pull
- 로컬(`localhost:PORT/purpose/all`) + 공개(`aws-api.oijwef098234.com` / `aws-stag.oijwef098234.com`) 헬스체크 통과 확인 후 종료

## 사전 준비 완료된 것
- `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY` GitHub Secrets를 현재 AWS 인스턴스 값으로 갱신함 (기존 값은 2026-02 시점의 다른 EC2를 가리키고 있었음)

## 미포함(후속 작업)
- Discord 배포 알림 — Webhook URL 정해지면 추가 예정
- IAM 개인 사용자 분리 (현재 루트 계정 세션 공유 상태)

## Test plan
- [ ] 이 PR을 develop에 머지한 뒤 실제 push로 stag 배포까지 정상 동작하는지 확인
- [ ] main에도 동일 워크플로우 반영 후 prod 배포 확인
- [ ] `docker compose ps`, `/purpose/all` 응답으로 배포 결과 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포**
  * AWS EC2 기반의 통합 배포 흐름을 도입했습니다.
  * 운영 및 스테이징 환경별 원격 배포 설정과 공개 헬스체크를 지원합니다.
  * 배포 전후 애플리케이션 상태를 자동으로 확인하며, 실패 시 배포를 중단합니다.
  * 배포 완료 후 사용하지 않는 Docker 이미지를 정리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->