### PR TITLE
토큰이 없을 때 403으로 뜨는 문제 해결

### DIFF
--- a/src/main/java/com/example/gujeuck_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/gujeuck_server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.gujeuck_server.global.config;
 
+import com.example.gujeuck_server.global.security.implementation.JwtAuthenticationEntryPoint;
 import com.example.gujeuck_server.global.security.jwt.JwtTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ import java.util.List;
 public class SecurityConfig {
     private final ObjectMapper objectMapper;
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Value("${cors.allowed-origins.prod-url}")
     private String prodUrl;
@@ -69,6 +71,8 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                    .authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .with(new SecurityFilterConfig(jwtTokenProvider, objectMapper), Customizer.withDefaults())
                 .build();
     }

--- a/src/main/java/com/example/gujeuck_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/gujeuck_server/global/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(401, "만료된 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(404, "RefreshToken이 존재 하지 않습니다."),
     INVALID_ROLE(401,"유효 하지 않은 역할입니다."),
+    TOKEN_NOT_FOUND(401, "인증정보가 비어있습니다."),
 
     //log
     LOG_NOT_FOUND(404, "존재하지 않는 이용목록입니다."),

--- a/src/main/java/com/example/gujeuck_server/global/security/implementation/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/gujeuck_server/global/security/implementation/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.example.gujeuck_server.global.security.implementation;
+
+import com.example.gujeuck_server.global.security.jwt.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void execute(HttpServletResponse response, HttpServletRequest request, AuthenticationException authException) {
+        
+    }
+
+}

--- a/src/main/java/com/example/gujeuck_server/global/security/implementation/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/gujeuck_server/global/security/implementation/JwtAuthenticationEntryPoint.java
@@ -19,7 +19,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void execute(HttpServletResponse response, HttpServletRequest request, AuthenticationException authException) throws IOException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         ErrorCode errorCode = ErrorCode.TOKEN_NOT_FOUND;
         response.setStatus(errorCode.getStatusCode());
         response.setContentType("application/json");

--- a/src/main/java/com/example/gujeuck_server/global/security/implementation/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/gujeuck_server/global/security/implementation/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.example.gujeuck_server.global.security.implementation;
 
+import com.example.gujeuck_server.global.error.ErrorResponse;
+import com.example.gujeuck_server.global.error.exception.ErrorCode;
 import com.example.gujeuck_server.global.security.jwt.JwtTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,14 +11,19 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void execute(HttpServletResponse response, HttpServletRequest request, AuthenticationException authException) {
-        
+    public void execute(HttpServletResponse response, HttpServletRequest request, AuthenticationException authException) throws IOException {
+        ErrorCode errorCode = ErrorCode.TOKEN_NOT_FOUND;
+        response.setStatus(errorCode.getStatusCode());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorCode, errorCode.getErrorMessage()));
     }
-
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 인증에 실패하거나 인증 정보가 누락된 경우, HTTP 401 상태와 일관된 JSON 오류 응답이 제공됩니다.
  * 인증 오류 메시지가 `"인증정보가 비어있습니다."`로 명확하게 안내됩니다.
  * 인증 실패 시 응답 형식과 문자 인코딩이 표준화되어 클라이언트에서 오류를 안정적으로 처리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->