### PR TITLE
유저 존재 여부 판단 API 수정

### DIFF
--- a/src/main/java/com/example/gujeuck_server/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/domain/repository/UserRepository.java
@@ -28,6 +28,8 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     Optional<User> findByNameAndPhone(String name, String phone);
 
+    List<User> findAllByName(String name);
+
     @Query(
             value = "select * from `user` where name = :name and regexp_replace(phone, '[^0-9]', '') = :phone",
             nativeQuery = true

--- a/src/main/java/com/example/gujeuck_server/domain/user/presentation/dto/request/UserExistsRequest.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/presentation/dto/request/UserExistsRequest.java
@@ -12,6 +12,4 @@ public class UserExistsRequest {
     @NotBlank(message = "이름은 필수 입력 항목입니다.")
     @Size(max = 30, message = "이름은 30자 이하로 입력해주세요.")
     private String name;
-
-    private String phone;
 }

--- a/src/main/java/com/example/gujeuck_server/domain/user/presentation/dto/response/UserExistsResponse.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/presentation/dto/response/UserExistsResponse.java
@@ -1,10 +1,12 @@
 package com.example.gujeuck_server.domain.user.presentation.dto.response;
 
+import java.util.List;
+
 public record UserExistsResponse(
         boolean userExists,
-        Long userId
+        List<Long> userIds
 ) {
-    public static UserExistsResponse of(boolean userExists, Long userId) {
-        return new UserExistsResponse(userExists, userId);
+    public static UserExistsResponse of(boolean userExists, List<Long> userIds) {
+        return new UserExistsResponse(userExists, userIds);
     }
 }

--- a/src/main/java/com/example/gujeuck_server/domain/user/service/SignupService.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/service/SignupService.java
@@ -54,7 +54,7 @@ public class SignupService {
 
         Purpose purpose = purposeFacade.getPurpose(organ.getId(), request.getPurpose());
 
-        User user = userRepository.findAllByNameAndNormalizedPhone(request.getName(), normalizePhone(request.getPhone())).stream()
+        User user = userRepository.findAllByName(request.getName()).stream()
                 .findFirst()
                 .orElseGet(() -> userRepository.save(createUser(request, age, request.getResidence(), organ)));
 
@@ -77,10 +77,6 @@ public class SignupService {
                 .age(age)
                 .organ(organ)
                 .build();
-    }
-
-    private String normalizePhone(String phone) {
-        return phone == null ? "" : phone.replaceAll("\\D", "");
     }
 
     private Log createLog(SignupRequest request, Age age, String purpose, String visitDate, String visitTime, LocalDateTime visitAt, int year, String residence, User user, Organ organ) {

--- a/src/main/java/com/example/gujeuck_server/domain/user/service/UserExistsService.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/service/UserExistsService.java
@@ -1,11 +1,14 @@
 package com.example.gujeuck_server.domain.user.service;
 
+import com.example.gujeuck_server.domain.user.domain.User;
 import com.example.gujeuck_server.domain.user.domain.repository.UserRepository;
 import com.example.gujeuck_server.domain.user.presentation.dto.request.UserExistsRequest;
 import com.example.gujeuck_server.domain.user.presentation.dto.response.UserExistsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,15 +18,10 @@ public class UserExistsService {
 
     @Transactional(readOnly = true)
     public UserExistsResponse execute(UserExistsRequest request) {
-        String normalizedPhone = normalizePhone(request.getPhone());
+        List<Long> userIds = userRepository.findAllByName(request.getName()).stream()
+                .map(User::getId)
+                .toList();
 
-        return userRepository.findAllByNameAndNormalizedPhone(request.getName(), normalizedPhone).stream()
-                .findFirst()
-                .map(user -> UserExistsResponse.of(true, user.getId()))
-                .orElseGet(() -> UserExistsResponse.of(false, null));
-    }
-
-    private String normalizePhone(String phone) {
-        return phone == null ? "" : phone.replaceAll("\\D", "");
+        return UserExistsResponse.of(!userIds.isEmpty(), userIds);
     }
 }

--- a/src/main/java/com/example/gujeuck_server/domain/user/service/UserSignUpHaService.java
+++ b/src/main/java/com/example/gujeuck_server/domain/user/service/UserSignUpHaService.java
@@ -42,18 +42,10 @@ public class UserSignUpHaService {
     }
 
     private User findOrCreateUser(Organ organ, HaDataSignUpRequest request) {
-        String normalizedPhone = normalizePhone(request.phone());
+        List<User> foundUsers = userRepository.findAllByName(request.name());
 
-        if (!normalizedPhone.isEmpty()) {
-            List<User> foundUsers =
-                userRepository.findAllByNameAndNormalizedPhone(
-                    request.name(),
-                    normalizedPhone
-                );
-
-            if (!foundUsers.isEmpty()) {
-                return foundUsers.get(0);
-            }
+        if (!foundUsers.isEmpty()) {
+            return foundUsers.get(0);
         }
 
         User newUser = User.builder()
@@ -68,9 +60,5 @@ public class UserSignUpHaService {
             .build();
 
         return userRepository.save(newUser);
-    }
-
-    private String normalizePhone(String phone) {
-        return phone == null ? "" : phone.replaceAll("\\D", "");
     }
 }


### PR DESCRIPTION
phone 필드를 요청/로직에서 제거하고 이름만으로 매칭하도록 변경.
동명이인이 있으면 userIds 배열로 전부 반환해 클라이언트가 각각
체크인 처리할 수 있게 함.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>